### PR TITLE
opacapp: update base image to current OpenJDK 8

### DIFF
--- a/opacapp/Dockerfile
+++ b/opacapp/Dockerfile
@@ -1,4 +1,4 @@
-FROM williamyeh/java8:latest
+FROM openjdk:8-buster
 
 MAINTAINER Raphael Michel
 

--- a/opacapp/Dockerfile
+++ b/opacapp/Dockerfile
@@ -3,7 +3,7 @@ FROM openjdk:8-buster
 MAINTAINER Raphael Michel
 
 RUN apt-get update && apt-get install -y  wget git lib32stdc++6 lib32z1 \
-	expect curl locales
+	expect curl locales fdroidserver
 
 RUN locale-gen
 RUN update-locale LANG=C.UTF-8
@@ -24,12 +24,6 @@ ENV ANDROID_HOME /android-sdk-linux
 RUN ( sleep 5 && while [ 1 ]; do sleep 1; echo y; done ) |\
 	/android-sdk-linux/tools/android update sdk --no-ui --all \
 	--filter "build-tools-22.0.1,build-tools-23.0.1,build-tools-23.0.2,build-tools-23.0.3,build-tools-24.0.0,build-tools-24.0.1,build-tools-25.0.0,build-tools-25.0.2,build-tools-25.0.3,build-tools-26.0.2,build-tools-28.0.3,build-tools-29.0.2,android-27,android-23,android-24,android-25,android-28,android-29,extra-android-m2repository,extra-android-support,platform-tools,addon-google_apis-google-23,extra-google-m2repository"; 
-
-# fdroidserver tools
-
-RUN echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main" >> /etc/apt/sources.list && \
-    apt-get -o Acquire::Check-Valid-Until=false update && \
-    apt-get -o Acquire::Check-Valid-Until=false -t jessie-backports install -y fdroidserver
     
 # Clean up
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
previous version was Oracle JDK 1.8.0_31

(I haven't tested if it works)